### PR TITLE
ensure timestamp is saved as mongo friendly ISODate

### DIFF
--- a/lib/logData.js
+++ b/lib/logData.js
@@ -5,7 +5,7 @@ module.exports = function(params, callback) {
 
   // Loop through parameters to update device sensor data
   var updates = {};
-  updates.timestamp = moment().toISOString()
+  updates.timestamp = new Date()
 
   for (var param in params) {
     var parsed;


### PR DESCRIPTION
Saving as just Date() makes Mongo save the date stamp as it's known ISODate type:

```
{ "timestamp" : ISODate("2014-03-25T08:36:15.048Z"), "uuid" : "f65ea8e0-ab7c-11e3-b66c-575bfd455815", "temperature" : "21.94", "pressure" : "1005.56", "light" : "2194", "humidity" : "99.9", "backdoor" : "1", "online" : "true", "ipAddress" : "192.168.0.201", "_id" : ObjectId("53313fff6ca137fe5e000001") }
```

This is instead of a string. This will allow all date range searches etc, to work as Mongo expects. http://cookbook.mongodb.org/patterns/date_range/ for examples.
