### PR TITLE
allow a time range to fetched from /data

### DIFF
--- a/lib/getData.js
+++ b/lib/getData.js
@@ -1,10 +1,30 @@
 var data = require('./database').collection('data');
 
-module.exports = function(uuid, callback) {
+module.exports = function(req, callback) {
 
-  data.find({
-    uuid:uuid
-  }).limit(10).sort({
+  var uuid = req.params.uuid;
+  var start = req.query.start; // time to start from
+  var finish = req.query.finish; // time to end
+  var limit = req.query.limit; // 0 bypasses the limit
+
+  var query = {
+    'uuid':uuid
+  }
+
+  // set a default limit
+  if (!limit) {
+    limit = 10;
+  } else {
+    limit = parseInt(limit);
+  }
+
+  if (start && finish) {
+    start = new Date(start);
+    finish = new Date(finish);
+    query['timestamp'] = {"$gte": start, "$lt": finish}
+  }
+
+  data.find(query).limit(limit).sort({
     $natural: -1
   }, function(err, eventdata) {
 

--- a/server.js
+++ b/server.js
@@ -1386,7 +1386,7 @@ server.get('/data/:uuid', function(req, res){
   res.setHeader('Access-Control-Allow-Origin','*');
   require('./lib/authDevice')(req.params.uuid, req.query.token, function(auth){
     if (auth.authenticate == true){
-      require('./lib/getData')(req.params.uuid, function(data){
+      require('./lib/getData')(req, function(data){
         console.log(data);
         if(data.error){
           res.json(data.error.code, data);


### PR DESCRIPTION
This is my first go at fetching data from /data limited by a timeframe. This adds start and end to to return all data entries matching in between those times.

```
curl -X GET localhost:3000/data/ef154af1-b5f2-11e3-8af7-f3d4ce6cbe76?token=03ezmz4tx50vvlsormq0jsb8wnv4e7b9\&start=2014-03-27T21:03:00\&finish=2014-03-27T21:03:59\&limit=10
```

This will return 10 entries from the data collection whos timestamp is between the start and finish times. It also adds "limit" to control the number of entries returned. Setting limit=0 bypasses any limits and returns all the values.
