### PR TITLE
Docker: fix redis config, create /var/log/skynet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ADD . /var/www
 RUN cd /var/www && npm install
 ADD ./docker/config.js.docker /var/www/config.js
 ADD ./docker/supervisor.conf /etc/supervisor/conf.d/supervisor.conf
+RUN mkdir /var/log/skynet
 
 EXPOSE 3000
 

--- a/docker/config.js.docker
+++ b/docker/config.js.docker
@@ -11,7 +11,9 @@ module.exports = {
     authId: "abc",
     authToken: "123"
   },*/
-  redisHost: "localhost",
-  redisPort: "6379",
-  redisPassword: "localhost"
+  redis: {
+    host: "localhost",
+    port: "6379",
+    password: "localhost"
+  }
 };


### PR DESCRIPTION
When I tried to run Skynet in Docker I got a few errors. With this patch I was able to run it.
- create /var/log/skynet
- in the config.js.docker (skynet config) match the redis settings to what the redis module expects.

Tested:
- build a new Docker image
- launch the image (docker run -i -t -p 3000 skynet:latest)
- create a new device in the localhost skynet
- use 'curl -X PUT' to update the device
