### PR TITLE
Change local skynet.js reference to skynet.im reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1508,7 +1508,7 @@ conn.on('ready', function(data){
 
 &lt;html&gt;
 &lt;head&gt;
-  &lt;script src="skynet.js"&gt;&lt;/script&gt;
+  &lt;script src="http://skynet.im/js/skynet.js"&gt;&lt;/script&gt;
   &lt;script&gt;
     var skynetConfig = {
       "uuid": "0d3a53a0-2a0b-11e3-b09c-ff4de847b2cc",


### PR DESCRIPTION
Update the reference to the `skynet.js` library to use the hosted one in the Examples section. This way the example code works "out of the box" :rocket:  
