### PR TITLE
fix for https params

### DIFF
--- a/server.js
+++ b/server.js
@@ -146,6 +146,14 @@ server.use(restify.fullResponse());
 //       burst: 0
 //     }
 //   }
+//
+
+// for https params
+https_server.use(restify.queryParser());
+https_server.use(restify.bodyParser());
+https_server.use(restify.CORS({ headers: [ 'skynet_auth_uuid', 'skynet_auth_token' ], origins: ['*'] }));
+https_server.use(restify.fullResponse());
+
 
 process.on("uncaughtException", function(error) {
   return console.log(error.stack);


### PR DESCRIPTION
I saw the problem that @chrismatthieu was talking about and this seemed to fix it and I'm able to get params from https POST requests.
