### PR TITLE
Added owner to configureWhitelist if specified on device registration.

### DIFF
--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -23,7 +23,7 @@ module.exports = (device={}, callback=_.noop, dependencies={}) ->
 
     device.token ?= generateToken()
     device.discoverWhitelist ?= [device.owner] if device.owner
-	device.configureWhitelist ?= [device.owner] if device.owner
+    device.configureWhitelist ?= [device.owner] if device.owner
 
     debug 'about to update device', device
     oldUpdateDevice newDevice.uuid, device, (error, savedDevice) =>

--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -23,6 +23,7 @@ module.exports = (device={}, callback=_.noop, dependencies={}) ->
 
     device.token ?= generateToken()
     device.discoverWhitelist ?= [device.owner] if device.owner
+	device.configureWhitelist ?= [device.owner] if device.owner
 
     debug 'about to update device', device
     oldUpdateDevice newDevice.uuid, device, (error, savedDevice) =>


### PR DESCRIPTION
claimdevice adds the owner to both the discoverWhitelist and configureWhitelist. Since specifying an owner property when registering a device claims it, this behavior should be mirrored there.